### PR TITLE
Feat: Add google calendar preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Unfortunately, Obsidian Mobile does not run on [Electron](https://www.electronjs
 By default, Custom Frames comes with a few presets that allow you to get new panes for popular sites up and running quickly.
 - [Obsidian Forum](https://forum.obsidian.md/)
 - [Google Keep](https://keep.google.com), optimized for a narrow pane on the side
+- [Google Calendar](https://calendar.google.com/calendar/u/0/r/day), optimized by removing some buttons. Close side panel with top-left button.
 - [Notion](https://www.notion.so/) (it's recommended to close Notion's sidebar if used as a side pane)
 - [Twitter](https://twitter.com)
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -11,6 +11,23 @@ export const presets: Record<string, CustomFrame> = {
         minimumWidth: 367,
         customCss: ""
     },
+	"calendar": {
+        url: "https://calendar.google.com/calendar/u/0/r/day",
+        displayName: "Google Calendar",
+        icon: "calendar",
+        hideOnMobile: true,
+        minimumWidth: 490,
+        customCss: `/* hide right-side menu, and some buttons */
+div.d6McF,
+div.pw6cBb,
+div.gb_Td.gb_Va.gb_Id,
+div.Kk7lMc-QWPxkf-LgbsSe-haAclf,
+div.h8Aqhb,
+div.gboEAb,
+div.dwlvNd {
+    display: none !important;
+}`
+    },
     "keep": {
         url: "https://keep.google.com",
         displayName: "Google Keep",


### PR DESCRIPTION
Google calendar presets that removes some (fairly) useless buttons to allow for extra space in the sidebar. 