### PR TITLE
Improve preset styling for Google Keeps frame

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -62,6 +62,9 @@ html > body > div:first-child > header:first-child > div > div:first-child > div
 html > body > div:first-child > header:first-child > div:nth-child(2) > div:first-child > div:first-child,
 html > body > div:first-child > header:first-child > div:nth-child(2) > div:nth-child(3) > div:first-child > div:first-child > div:first-child {
 	display: none !important;
+}
+html > body > div:first-child > header:first-child > div > div:first-child > div > div:first-child > a:first-child {
+	cursor: default;
 }`
     },
     "todoist": {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -56,9 +56,11 @@ div[style*="min-width: 238px"] span[role*="heading"] {
         openInCenter: false,
         zoomLevel: 1,
         forceIframe: false,
-        customCss: `/* hide the menu bar and the "Keep" text */
+        customCss: `/* hide the menu bar, the "Keep" text and the Google Apps button */
 html > body > div:nth-child(2) > div:nth-child(2) > div:first-child,
-html > body > div:first-child > header:first-child > div > div:first-child > div > div:first-child > a:first-child > span {
+html > body > div:first-child > header:first-child > div > div:first-child > div > div:first-child > a:first-child > span,
+html > body > div:first-child > header:first-child > div:nth-child(2) > div:first-child > div:first-child,
+html > body > div:first-child > header:first-child > div:nth-child(2) > div:nth-child(3) > div:first-child > div:first-child > div:first-child {
 	display: none !important;
 }`
     },

--- a/test-vault/.obsidian/plugins/obsidian-custom-frames/data.json
+++ b/test-vault/.obsidian/plugins/obsidian-custom-frames/data.json
@@ -20,7 +20,7 @@
       "openInCenter": false,
       "zoomLevel": 1,
       "forceIframe": false,
-      "customCss": "/* hide the menu bar and the \"Keep\" text */\nhtml > body > div:nth-child(2) > div:nth-child(2) > div:first-child, \nhtml > body > div:first-child > header:first-child > div > div:first-child > div > div:first-child > a:first-child > span { \n\tdisplay: none !important; \n}"
+      "customCss": "/* hide the menu bar, the \"Keep\" text and the Google Apps button */\nhtml > body > div:nth-child(2) > div:nth-child(2) > div:first-child, \nhtml > body > div:first-child > header:first-child > div > div:first-child > div > div:first-child > a:first-child > span, \nhtml > body > div:first-child > header:first-child > div:nth-child(2) > div:first-child > div:first-child, \nhtml > body > div:first-child > header:first-child > div:nth-child(2) > div:nth-child(3) > div:first-child > div:first-child > div:first-child { \n\tdisplay: none !important; \n}"
     },
     {
       "url": "https://calendar.google.com/calendar",

--- a/test-vault/.obsidian/plugins/obsidian-custom-frames/data.json
+++ b/test-vault/.obsidian/plugins/obsidian-custom-frames/data.json
@@ -20,7 +20,7 @@
       "openInCenter": false,
       "zoomLevel": 1,
       "forceIframe": false,
-      "customCss": "/* hide the menu bar, the \"Keep\" text and the Google Apps button */\nhtml > body > div:nth-child(2) > div:nth-child(2) > div:first-child, \nhtml > body > div:first-child > header:first-child > div > div:first-child > div > div:first-child > a:first-child > span, \nhtml > body > div:first-child > header:first-child > div:nth-child(2) > div:first-child > div:first-child, \nhtml > body > div:first-child > header:first-child > div:nth-child(2) > div:nth-child(3) > div:first-child > div:first-child > div:first-child { \n\tdisplay: none !important; \n}"
+      "customCss": "/* hide the menu bar, the \"Keep\" text and the Google Apps button */\nhtml > body > div:nth-child(2) > div:nth-child(2) > div:first-child, \nhtml > body > div:first-child > header:first-child > div > div:first-child > div > div:first-child > a:first-child > span, \nhtml > body > div:first-child > header:first-child > div:nth-child(2) > div:first-child > div:first-child, \nhtml > body > div:first-child > header:first-child > div:nth-child(2) > div:nth-child(3) > div:first-child > div:first-child > div:first-child { \n\tdisplay: none !important; \n}\nhtml > body > div:first-child > header:first-child > div > div:first-child > div > div:first-child > a:first-child {\n\tcursor: default; \n}"
     },
     {
       "url": "https://calendar.google.com/calendar",


### PR DESCRIPTION
Add other unnecessary stuff to the list of hidden elements in the preset styling for Google Keeps frame:
- Hamburger menu icon
- Google Apps button 

![image](https://github.com/Ellpeck/ObsidianCustomFrames/assets/53261024/1a2f1643-9f11-4b98-821e-7fb6411824ea)
